### PR TITLE
feat: Implement Editor Tab and Fix Capture Area

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,19 +12,18 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     });
     return true;
   } else if (request.action === "initiateAreaCapture") {
-    // This message comes from popup.js
-    // We need the tab ID to inject the content script.
-    // The sender object for a message from a popup doesn't directly include sender.tab.id
-    // for the *active* tab. We need to query for it.
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       if (tabs && tabs.length > 0) {
         const activeTabId = tabs[0].id;
-        // Check if the URL is a restricted one before trying to inject.
-        if (tabs[0].url && (tabs[0].url.startsWith('chrome://') || tabs[0].url.startsWith('https://chrome.google.com/webstore'))) {
-            console.warn(`Cannot inject script into restricted URL: ${tabs[0].url}`);
-            // Optionally send a message back to popup indicating failure
-            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: "Cannot capture selected area on this page due to restrictions." });
-            return;
+        const activeTabUrl = tabs[0].url;
+
+        if (activeTabUrl && (activeTabUrl.startsWith('chrome://') || activeTabUrl.startsWith('https://chrome.google.com/webstore'))) {
+          const errorMsg = "Cannot capture selected area on this page due to restrictions.";
+          console.warn(`Attempted to inject script into restricted URL: ${activeTabUrl}`);
+          chrome.storage.local.set({ pendingAreaCaptureError: errorMsg }, () => {
+            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: errorMsg, fromStorage: true });
+          });
+          return;
         }
 
         chrome.scripting.executeScript({
@@ -32,37 +31,47 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           files: ["content_script.js"]
         }, (injectionResults) => {
           if (chrome.runtime.lastError) {
-            console.error("Error injecting content script:", chrome.runtime.lastError.message);
-            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: chrome.runtime.lastError.message });
-          } else if (!injectionResults || injectionResults.length === 0 || !injectionResults[0].result) {
-            // This case might happen if the content script couldn't execute, e.g. due to page's CSP
-            // console.warn("Content script injection result was empty or unsuccessful, or script itself had an error.");
-            // chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: "Failed to execute selection script on the page." });
+            const errorMsg = `Error injecting content script: ${chrome.runtime.lastError.message}`;
+            console.error(errorMsg);
+            chrome.storage.local.set({ pendingAreaCaptureError: errorMsg }, () => {
+              chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: errorMsg, fromStorage: true });
+            });
+          } else if (!injectionResults || injectionResults.length === 0) {
+             // This case means the content script was injected but did not return a result (e.g., it threw an error itself before sending a message)
+             // No specific error from chrome.scripting, but the script might not have run as expected.
+             // content_script.js itself will send a message if it fails before selection (e.g. min size)
+             console.log("Content script for area capture injected, awaiting user selection or script error.");
           } else {
             console.log("Content script for area capture injected successfully.");
           }
         });
       } else {
-        console.error("No active tab found to inject content script.");
-        chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: "No active tab found." });
+        const errorMsg = "No active tab found to inject content script.";
+        console.error(errorMsg);
+        chrome.storage.local.set({ pendingAreaCaptureError: errorMsg }, () => {
+            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: errorMsg, fromStorage: true });
+        });
       }
     });
-    // No sendResponse needed here as this is initiating an action, not returning data directly
-    return false; // Not using sendResponse asynchronously from this specific handler path
+    return false;
   } else if (request.action === "captureAreaCoords") {
-    // This message comes from content_script.js
     const { x, y, width, height, devicePixelRatio } = request.coords;
 
     chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
       if (chrome.runtime.lastError) {
-        console.error("Failed to capture visible tab for area crop:", chrome.runtime.lastError.message);
-        // Inform popup if possible, though it might be closed.
-        chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: chrome.runtime.lastError.message });
-        return; // No sendResponse as this is an async error in a callback
+        const errorMsg = `Failed to capture visible tab for area crop: ${chrome.runtime.lastError.message}`;
+        console.error(errorMsg);
+        chrome.storage.local.set({ pendingAreaCaptureError: errorMsg }, () => {
+            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: errorMsg, fromStorage: true });
+        });
+        return;
       }
       if (!dataUrl) {
-        console.error("captureVisibleTab returned empty dataUrl.");
-        chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: "Capture returned no data." });
+        const errorMsg = "CaptureVisibleTab returned empty dataUrl.";
+        console.error(errorMsg);
+        chrome.storage.local.set({ pendingAreaCaptureError: errorMsg }, () => {
+            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: errorMsg, fromStorage: true });
+        });
         return;
       }
 
@@ -71,20 +80,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         const tempCanvas = document.createElement('canvas');
         const tempCtx = tempCanvas.getContext('2d');
 
-        // Adjust coordinates and dimensions by devicePixelRatio
-        const sx = x * devicePixelRatio;
-        const sy = y * devicePixelRatio;
-        const sWidth = width * devicePixelRatio;
-        const sHeight = height * devicePixelRatio;
+        const sx = x * devicePixelRatio; const sy = y * devicePixelRatio;
+        const sWidth = width * devicePixelRatio; const sHeight = height * devicePixelRatio;
 
-        tempCanvas.width = sWidth;
-        tempCanvas.height = sHeight;
+        tempCanvas.width = sWidth; tempCanvas.height = sHeight;
 
-        // Ensure source image dimensions are sufficient before drawing
         if (img.width < sx + sWidth || img.height < sy + sHeight) {
-            console.error("Error: Crop area is outside the bounds of the captured image.",
-                          {imgW: img.width, imgH: img.height, sx, sy, sWidth, sHeight});
-            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: "Selected area was outside the captured image bounds." });
+            const errorMsg = "Selected area was outside the captured image bounds.";
+            console.error(errorMsg, {imgW: img.width, imgH: img.height, sx, sy, sWidth, sHeight});
+            chrome.storage.local.set({ pendingAreaCaptureError: errorMsg }, () => {
+                chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: errorMsg, fromStorage: true });
+            });
             return;
         }
 
@@ -92,25 +98,30 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
         try {
             const croppedDataUrl = tempCanvas.toDataURL('image/png');
-            // Send this back to the extension's runtime (popup.js will listen)
-            chrome.runtime.sendMessage({ action: "areaCaptured", dataUrl: croppedDataUrl });
+            chrome.storage.local.set({ pendingAreaCapture: croppedDataUrl }, () => {
+                console.log("Cropped area capture saved to storage.");
+                // Attempt to send direct message to popup as an optimization
+                chrome.runtime.sendMessage({ action: "areaCaptured", dataUrl: croppedDataUrl, fromStorage: false });
+                // Note: We don't remove from storage here. Popup will do it after loading.
+            });
         } catch (e) {
-            console.error("Error converting canvas to Data URL:", e);
-            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: "Could not process captured area." });
+            const errorMsg = `Could not process captured area (toDataURL failed): ${e.message}`;
+            console.error(errorMsg);
+            chrome.storage.local.set({ pendingAreaCaptureError: errorMsg }, () => {
+                chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: errorMsg, fromStorage: true });
+            });
         }
       };
       img.onerror = () => {
-        console.error("Failed to load captured image for processing.");
-        chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: "Failed to load captured image." });
+        const errorMsg = "Failed to load captured image for processing (img.onerror).";
+        console.error(errorMsg);
+        chrome.storage.local.set({ pendingAreaCaptureError: errorMsg }, () => {
+            chrome.runtime.sendMessage({ action: "areaCaptureFailed", error: errorMsg, fromStorage: true });
+        });
       };
       img.src = dataUrl;
     });
-    // sendResponse is not used here because the response is sent via a new chrome.runtime.sendMessage
-    return false; // Not using sendResponse from this handler
+    return false;
   }
-  // Return true for handlers that will use sendResponse asynchronously.
-  // For "initiateAreaCapture" and "captureAreaCoords", they don't use sendResponse directly to the caller of *this specific message*,
-  // but rather initiate new messages or actions.
-  // The original "capture" action *does* use sendResponse.
-  return request.action === "capture";
+  return request.action === "capture"; // Only "capture" uses sendResponse directly and needs to return true.
 });

--- a/editor.css
+++ b/editor.css
@@ -1,0 +1,192 @@
+/* General Reset / Base */
+body, html {
+    margin: 0;
+    padding: 0;
+    font-family: sans-serif;
+    background-color: #f0f0f0; /* Light background for the page */
+    height: 100%;
+    overflow: hidden; /* Prevent scrollbars on body due to flex */
+}
+
+.editor-container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh; /* Full viewport height */
+}
+
+.editor-header {
+    background-color: #333;
+    color: white;
+    padding: 10px 20px;
+    text-align: center;
+}
+.editor-header h1 {
+    margin: 0;
+    font-size: 1.8em;
+}
+
+.editor-main {
+    display: flex;
+    flex-grow: 1; /* Takes remaining vertical space */
+    overflow: hidden; /* Prevent internal scroll issues if sidebar/canvas area are too big */
+}
+
+.editor-sidebar {
+    width: 280px; /* Fixed width sidebar */
+    padding: 15px;
+    background-color: #f9f9f9;
+    border-right: 1px solid #ddd;
+    overflow-y: auto; /* Allow sidebar to scroll if content is too long */
+    display: flex;
+    flex-direction: column;
+}
+.editor-sidebar h2 {
+    font-size: 1.3em;
+    text-align: center;
+    color: #333;
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+
+.editor-canvas-area {
+    flex-grow: 1; /* Takes remaining horizontal space */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+    background-color: #e9e9e9; /* Background for canvas area */
+    overflow: auto; /* Allow scrolling for large images */
+}
+
+#editorCanvas {
+  border: 2px solid #ccc;
+  background-color: #fff;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+  /* Max width/height will be set by JS based on image, or constrained by parent */
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain; /* Ensure canvas itself scales if needed, though drawing is direct */
+}
+
+/* Re-use popup.css styles for controls, with minor adjustments if needed */
+.controls-container {
+  margin-top: 0; /* Adjusted from popup.css */
+  margin-bottom: 20px; /* Space before output actions */
+  padding: 10px;
+  background-color: #f0f0f0; /* Keep consistent with overall page bg or slightly different */
+  border-radius: 4px;
+}
+
+.control-group {
+  margin-bottom: 12px; /* Slightly more spacing */
+  display: flex;
+  align-items: center;
+}
+.control-group:last-child {
+  margin-bottom: 0;
+}
+
+.control-group label {
+  display: inline-block;
+  margin-right: 10px;
+  width: 80px; /* Slightly adjust if needed */
+  font-size: 0.9em;
+  color: #444;
+}
+
+.control-group input[type="color"],
+.control-group input[type="number"],
+.control-group input[type="text"] {
+  flex-grow: 1;
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+.control-group input[type="color"] {
+  min-width: 50px; /* Ensure color picker is not too small */
+  height: 32px;
+  flex-grow: 0; /* Don't let color picker grow too much */
+}
+.control-group input[type="checkbox"] {
+    margin-left: 5px; /* Align checkbox better */
+}
+
+
+button { /* General button styling */
+  margin: 8px 0; /* More vertical margin for grouped buttons */
+  padding: 10px 15px;
+  font-size: 0.95em; /* Slightly larger font for editor page */
+  color: #fff;
+  background-color: #007bff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  transition: background-color 0.2s ease;
+}
+button:hover {
+  background-color: #0056b3;
+}
+
+.tool-btn {
+  background-color: #6c757d;
+  margin-bottom: 10px;
+}
+.tool-btn:hover {
+  background-color: #5a6268;
+}
+.tool-btn.active {
+  background-color: #007bff;
+  font-weight: bold;
+  box-shadow: 0 0 8px rgba(0, 123, 255, 0.6);
+}
+
+#applyCropBtn {
+    background-color: #ffc107;
+    color: #212529;
+}
+#applyCropBtn:hover {
+    background-color: #e0a800;
+}
+
+.output-actions { /* For Save, Copy buttons */
+  display: flex;
+  gap: 10px;
+  margin-top: auto; /* Pushes to the bottom of the sidebar */
+  padding-top: 15px; /* Space above output actions */
+  border-top: 1px solid #ddd; /* Separator */
+}
+.output-actions button {
+  flex-grow: 1;
+}
+
+#saveBtn {
+  background-color: #28a745;
+}
+#saveBtn:hover {
+  background-color: #1e7e34;
+}
+#copyToClipboardBtn {
+    background-color: #17a2b8;
+}
+#copyToClipboardBtn:hover {
+    background-color: #117a8b;
+}
+
+hr.tool-separator {
+  margin: 15px 0;
+  border: 0;
+  border-top: 1px solid #ddd;
+}
+
+#noImageMessage {
+    font-size: 1.2em;
+    color: #777;
+}
+/* Hide specific controls by default, JS will show them */
+.text-tool-control, .shape-tool-control {
+    /* display: none; -- JS handles this now based on setActiveTool */
+}

--- a/editor.html
+++ b/editor.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Editor</title>
+    <link rel="stylesheet" href="editor.css">
+</head>
+<body>
+    <div class="editor-container">
+        <header class="editor-header">
+            <h1>Image Editor</h1>
+        </header>
+
+        <div class="editor-main">
+            <aside class="editor-sidebar">
+                <h2>Tools</h2>
+                <div class="controls-container">
+                    <button id="drawToolBtn" class="tool-btn">Draw</button>
+                    <button id="cropBtn" class="tool-btn">Crop</button>
+                    <button id="textToolBtn" class="tool-btn">Text</button>
+                    <button id="rectToolBtn" class="tool-btn">Rectangle</button>
+                    <button id="circleToolBtn" class="tool-btn">Circle</button>
+
+                    <hr class="tool-separator">
+
+                    <div class="control-group">
+                        <label for="colorPicker">Color:</label>
+                        <input type="color" id="colorPicker" value="#FF0000">
+                    </div>
+                    <div class="control-group">
+                        <label for="lineWidth">Line Width:</label>
+                        <input type="number" id="lineWidth" value="5" min="1" max="50">
+                    </div>
+
+                    <!-- Text Tool Specific -->
+                    <div class="control-group text-tool-control" style="display:none;">
+                        <label for="textInput">Text:</label>
+                        <input type="text" id="textInput" placeholder="Enter text">
+                    </div>
+                    <div class="control-group text-tool-control" style="display:none;">
+                        <label for="fontSizeInput">Font Size:</label>
+                        <input type="number" id="fontSizeInput" value="16" min="8" max="72">px
+                    </div>
+
+                    <!-- Shape Tool Specific -->
+                    <div class="control-group shape-tool-control" style="display:none;">
+                        <label for="shapeFillCheckbox" style="width: auto; margin-right: 5px;">Fill Shape:</label>
+                        <input type="checkbox" id="shapeFillCheckbox">
+                    </div>
+
+                    <hr class="tool-separator">
+                    <button id="applyCropBtn" style="display:none; background-color: #ffc107;">Apply Crop</button>
+                </div>
+
+                <div class="output-actions editor-output-actions">
+                    <button id="saveBtn">Save Image</button>
+                    <button id="copyToClipboardBtn">Copy to Clipboard</button>
+                </div>
+            </aside>
+
+            <section class="editor-canvas-area">
+                <canvas id="editorCanvas"></canvas>
+                <p id="noImageMessage" style="display:none; text-align:center;">
+                    No image loaded. Capture or select an image via the extension popup.
+                </p>
+            </section>
+        </div>
+    </div>
+    <script src="editor.js"></script>
+</body>
+</html>

--- a/editor.js
+++ b/editor.js
@@ -1,0 +1,307 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const editorCanvas = document.getElementById('editorCanvas');
+    const ctx = editorCanvas.getContext('2d');
+    const noImageMessage = document.getElementById('noImageMessage');
+
+    // --- Element References from popup.js (ensure IDs match in editor.html) ---
+    const colorPicker = document.getElementById('colorPicker');
+    const lineWidthInput = document.getElementById('lineWidth');
+    const saveBtn = document.getElementById('saveBtn');
+    const copyToClipboardBtn = document.getElementById('copyToClipboardBtn');
+
+    const drawToolBtn = document.getElementById('drawToolBtn');
+    const cropBtn = document.getElementById('cropBtn');
+    const applyCropBtn = document.getElementById('applyCropBtn');
+    const textToolBtn = document.getElementById('textToolBtn');
+    const textInput = document.getElementById('textInput');
+    const fontSizeInput = document.getElementById('fontSizeInput');
+    const rectToolBtn = document.getElementById('rectToolBtn');
+    const circleToolBtn = document.getElementById('circleToolBtn');
+    const shapeFillCheckbox = document.getElementById('shapeFillCheckbox');
+
+    const canvasToolBtns = [drawToolBtn, cropBtn, textToolBtn, rectToolBtn, circleToolBtn];
+
+    // --- State Variables (mirrored from popup.js, but specific to editor) ---
+    let isDrawing, lastX, lastY, currentTool = 'draw', cropRect, isCropping, shapeStartCoords, isDrawingShape;
+    let editorOriginalImageSrc = null; // Primary image data for the editor
+
+    // --- Load Image from Storage ---
+    function loadInitialImage() {
+        chrome.storage.local.get("imageToEditInEditor", (result) => {
+            if (chrome.runtime.lastError) {
+                console.error("Error getting image from storage:", chrome.runtime.lastError);
+                noImageMessage.textContent = "Error loading image. Please try again.";
+                noImageMessage.style.display = "block";
+                return;
+            }
+            if (result.imageToEditInEditor) {
+                const dataUrl = result.imageToEditInEditor;
+                const image = new Image();
+                image.onload = () => {
+                    editorCanvas.width = image.width;
+                    editorCanvas.height = image.height;
+                    ctx.drawImage(image, 0, 0);
+                    editorOriginalImageSrc = editorCanvas.toDataURL(); // Use canvas data after drawing
+                    noImageMessage.style.display = "none";
+                    setActiveTool('draw'); // Set default tool after image loads
+                };
+                image.onerror = () => {
+                    console.error("Failed to load imageToEditInEditor from data URL.");
+                    noImageMessage.textContent = "Could not load the image data.";
+                    noImageMessage.style.display = "block";
+                };
+                image.src = dataUrl;
+                chrome.storage.local.remove("imageToEditInEditor", () => {
+                    console.log("Cleared imageToEditInEditor from storage.");
+                });
+            } else {
+                noImageMessage.style.display = "block";
+                // Disable editing controls if no image? Or allow drawing on blank canvas?
+                // For now, most tools check for editorOriginalImageSrc.
+            }
+        });
+    }
+    loadInitialImage();
+
+    // --- Helper Functions (Ported and adapted from popup.js) ---
+    function getMousePos(canvas, evt) {
+        const rect = canvas.getBoundingClientRect();
+        // Consider canvas scaling if its display size is different from its resolution
+        return {
+            x: (evt.clientX - rect.left) * (canvas.width / rect.width),
+            y: (evt.clientY - rect.top) * (canvas.height / rect.height)
+        };
+    }
+
+    function setActiveTool(toolName) {
+        currentTool = toolName;
+        isDrawing = isCropping = isDrawingShape = false;
+        shapeStartCoords = cropRect = null;
+
+        canvasToolBtns.forEach(btn => btn && btn.classList.remove('active'));
+
+        const activeBtn = document.getElementById(toolName + "ToolBtn");
+        if (activeBtn && canvasToolBtns.includes(activeBtn)) {
+            activeBtn.classList.add('active');
+        }
+
+        applyCropBtn.style.display = 'none';
+        if (toolName === 'crop' && editorOriginalImageSrc) {
+            redrawOriginalImage();
+        }
+
+        // Controls visibility based on current tool
+        const textToolControls = document.querySelectorAll('.text-tool-control');
+        textToolControls.forEach(el => el.style.display = (toolName === 'text') ? 'flex' : 'none');
+
+        const shapeToolControls = document.querySelectorAll('.shape-tool-control');
+        shapeToolControls.forEach(el => el.style.display = (toolName === 'rectangle' || toolName === 'circle') ? 'flex' : 'none');
+
+        colorPicker.parentElement.style.display = ['draw', 'text', 'rectangle', 'circle'].includes(toolName) ? 'flex' : 'none';
+        lineWidthInput.parentElement.style.display = ['draw', 'rectangle', 'circle'].includes(toolName) ? 'flex' : 'none';
+        console.log("Editor Active tool:", currentTool);
+    }
+
+    function redrawOriginalImage(callback) {
+        if (!editorOriginalImageSrc) {
+            ctx.clearRect(0, 0, editorCanvas.width, editorCanvas.height); // Clear if no base image
+            if (callback) callback();
+            return;
+        }
+        const img = new Image();
+        img.onload = () => {
+            // Ensure canvas is sized to the image being redrawn if it's different
+            if (editorCanvas.width !== img.width || editorCanvas.height !== img.height) {
+                 editorCanvas.width = img.width; editorCanvas.height = img.height;
+            }
+            ctx.clearRect(0, 0, editorCanvas.width, editorCanvas.height);
+            ctx.drawImage(img, 0, 0);
+            if (callback) callback();
+        };
+        img.onerror = () => { console.error("Editor: Error loading original image for redraw."); if (callback) callback(); };
+        img.src = editorOriginalImageSrc;
+    }
+
+    // --- Tool Button Event Listeners ---
+    if (drawToolBtn) drawToolBtn.addEventListener('click', () => setActiveTool('draw'));
+    if (cropBtn) cropBtn.addEventListener('click', () => setActiveTool('crop'));
+    if (textToolBtn) textToolBtn.addEventListener('click', () => { setActiveTool('text'); if (textInput) textInput.focus(); });
+    if (rectToolBtn) rectToolBtn.addEventListener('click', () => setActiveTool('rectangle'));
+    if (circleToolBtn) circleToolBtn.addEventListener('click', () => setActiveTool('circle'));
+
+    // --- Action Buttons (Apply Crop) ---
+    applyCropBtn.addEventListener('click', () => {
+        if (cropRect && editorOriginalImageSrc) {
+            const img = new Image();
+            img.onload = () => {
+                const cw = Math.abs(cropRect.endX - cropRect.startX);
+                const ch = Math.abs(cropRect.endY - cropRect.startY);
+                const csX = Math.min(cropRect.startX, cropRect.endX);
+                const csY = Math.min(cropRect.startY, cropRect.endY);
+
+                if (cw < 1 || ch < 1) { setActiveTool('draw'); return; }
+
+                const tempC = document.createElement('canvas'); tempC.width = img.width; tempC.height = img.height;
+                tempC.getContext('2d').drawImage(img, 0, 0); // Draw current editorOriginalImageSrc to temp canvas
+
+                editorCanvas.width = cw; editorCanvas.height = ch; // Resize main canvas
+                ctx.clearRect(0, 0, cw, ch);
+                ctx.drawImage(tempC, csX, csY, cw, ch, 0, 0, cw, ch); // Draw cropped part
+                editorOriginalImageSrc = editorCanvas.toDataURL(); // Update base image
+                setActiveTool('draw');
+            };
+            img.src = editorOriginalImageSrc; // Use the current base image for cropping
+        } else {
+            setActiveTool('draw');
+        }
+    });
+
+    // --- Canvas Event Handlers (Ported and adapted) ---
+    editorCanvas.addEventListener('mousedown', (e) => {
+        if (!editorOriginalImageSrc && currentTool !== 'text' && currentTool !== 'draw') { // Allow draw/text on blank canvas
+             if (currentTool !== 'text' && currentTool !== 'draw' || ((currentTool === 'text' || currentTool === 'draw') && (editorCanvas.width === 0 || editorCanvas.height === 0)) ) {
+                 console.warn("No image loaded or canvas not ready."); return;
+             }
+        }
+        const pos = getMousePos(editorCanvas, e);
+
+        if (currentTool === 'draw') {
+            isDrawing = true; [lastX, lastY] = [pos.x, pos.y];
+            ctx.beginPath(); ctx.moveTo(lastX, lastY);
+            ctx.strokeStyle = colorPicker.value; ctx.lineWidth = lineWidthInput.value;
+            ctx.lineCap = 'round'; ctx.lineJoin = 'round';
+        } else if (currentTool === 'crop') {
+            if (!editorOriginalImageSrc) return;
+            isCropping = true; cropRect = { startX: pos.x, startY: pos.y, endX: pos.x, endY: pos.y };
+            applyCropBtn.style.display = 'none';
+        } else if (currentTool === 'text') {
+            const text = textInput.value.trim(); if (!text) { alert("Please enter text."); return; }
+            const fontSize = fontSizeInput.value || "16";
+            // Redraw necessary if text is added to existing image, not strictly if on blank
+            if (editorOriginalImageSrc) redrawOriginalImage(() => drawText(text, pos.x, pos.y, fontSize, colorPicker.value));
+            else drawText(text, pos.x, pos.y, fontSize, colorPicker.value); // Draw on blank canvas
+
+        } else if (currentTool === 'rectangle' || currentTool === 'circle') {
+            if (!editorOriginalImageSrc && (editorCanvas.width === 0 || editorCanvas.height === 0)) return; // Need a canvas to draw on
+            isDrawingShape = true; shapeStartCoords = pos;
+        }
+    });
+
+    function drawText(text, x, y, fontSize, color) {
+        ctx.font = `${fontSize}px sans-serif`; ctx.fillStyle = color;
+        ctx.fillText(text, x, y);
+        editorOriginalImageSrc = editorCanvas.toDataURL(); // Update base image
+    }
+
+    editorCanvas.addEventListener('mousemove', (e) => {
+        // Allow preview even if editorOriginalImageSrc is null for draw/shape tools on a blank canvas
+        const pos = getMousePos(editorCanvas, e);
+
+        if (currentTool === 'draw' && isDrawing) {
+            ctx.lineTo(pos.x, pos.y); ctx.stroke(); [lastX, lastY] = [pos.x, pos.y];
+        } else if (currentTool === 'crop' && isCropping && cropRect) {
+            if (!editorOriginalImageSrc) return; // Crop only makes sense on an image
+            cropRect.endX = pos.x; cropRect.endY = pos.y;
+            redrawOriginalImage(() => {
+                ctx.strokeStyle='rgba(255,0,0,0.7)'; ctx.lineWidth=1; ctx.setLineDash([4,2]);
+                ctx.strokeRect(cropRect.startX, cropRect.startY, cropRect.endX-cropRect.startX, cropRect.endY-cropRect.startY);
+                ctx.setLineDash([]);
+            });
+        } else if ((currentTool === 'rectangle' || currentTool === 'circle') && isDrawingShape && shapeStartCoords) {
+            const drawCurrentShapePreview = () => {
+                ctx.beginPath(); ctx.strokeStyle=colorPicker.value; ctx.lineWidth=lineWidthInput.value;
+                const fill = shapeFillCheckbox.checked; if (fill) ctx.fillStyle=colorPicker.value;
+                if (currentTool === 'rectangle') {
+                    ctx.rect(shapeStartCoords.x, shapeStartCoords.y, pos.x-shapeStartCoords.x, pos.y-shapeStartCoords.y);
+                } else {
+                    const rX=Math.abs(pos.x-shapeStartCoords.x)/2; const rY=Math.abs(pos.y-shapeStartCoords.y)/2;
+                    const cX=Math.min(shapeStartCoords.x,pos.x)+rX; const cY=Math.min(shapeStartCoords.y,pos.y)+rY;
+                    ctx.ellipse(cX,cY,rX,rY,0,0,2*Math.PI);
+                }
+                if (fill) ctx.fill(); ctx.stroke();
+            };
+            if (editorOriginalImageSrc) redrawOriginalImage(drawCurrentShapePreview);
+            else { // Drawing shape on blank canvas
+                ctx.clearRect(0,0, editorCanvas.width, editorCanvas.height); // Clear for preview
+                drawCurrentShapePreview();
+            }
+        }
+    });
+
+    editorCanvas.addEventListener('mouseup', (e) => {
+        const finalPos = getMousePos(editorCanvas, e);
+        if (currentTool === 'draw' && isDrawing) {
+            isDrawing=false; editorOriginalImageSrc=editorCanvas.toDataURL(); // Commit draw
+        } else if (currentTool === 'crop' && isCropping) {
+            isCropping=false; if (!editorOriginalImageSrc) return;
+            if (cropRect && (Math.abs(cropRect.endX-cropRect.startX)>5 && Math.abs(cropRect.endY-cropRect.startY)>5)) {
+                applyCropBtn.style.display='block';
+            } else { cropRect=null; redrawOriginalImage(); }
+        } else if ((currentTool === 'rectangle' || currentTool === 'circle') && isDrawingShape && shapeStartCoords) {
+            isDrawingShape=false;
+            const drawFinalShape = () => {
+                ctx.beginPath(); ctx.strokeStyle=colorPicker.value; ctx.lineWidth=lineWidthInput.value;
+                const fill=shapeFillCheckbox.checked; if(fill)ctx.fillStyle=colorPicker.value;
+                if (currentTool === 'rectangle') {
+                    ctx.rect(shapeStartCoords.x,shapeStartCoords.y,finalPos.x-shapeStartCoords.x,finalPos.y-shapeStartCoords.y);
+                } else {
+                    const rX=Math.abs(finalPos.x-shapeStartCoords.x)/2; const rY=Math.abs(finalPos.y-shapeStartCoords.y)/2;
+                    const cX=Math.min(shapeStartCoords.x,finalPos.x)+rX; const cY=Math.min(shapeStartCoords.y,finalPos.y)+rY;
+                    ctx.ellipse(cX,cY,rX,rY,0,0,2*Math.PI);
+                }
+                if(fill)ctx.fill(); ctx.stroke();
+                editorOriginalImageSrc=editorCanvas.toDataURL(); // Commit shape
+            };
+            if (editorOriginalImageSrc) redrawOriginalImage(drawFinalShape);
+            else { // Final shape on blank canvas
+                 ctx.clearRect(0,0, editorCanvas.width, editorCanvas.height); // Clear preview
+                 drawFinalShape();
+            }
+            shapeStartCoords=null;
+        }
+    });
+
+    editorCanvas.addEventListener('mouseout', (e) => {
+        if (isDrawing) { isDrawing=false; editorOriginalImageSrc = editorCanvas.toDataURL(); }
+        else if (isCropping) { isCropping=false; /* Crop selection persists until new tool or apply */ }
+        else if (isDrawingShape) {
+            isDrawingShape=false; shapeStartCoords=null;
+            if(editorOriginalImageSrc) redrawOriginalImage(); // Clear preview
+            else ctx.clearRect(0,0, editorCanvas.width, editorCanvas.height);
+        }
+    });
+
+    // --- Output Functions (Ported) ---
+    saveBtn.addEventListener('click', () => {
+        if (!editorOriginalImageSrc && editorCanvas.width === 0) { alert("Canvas is empty."); return; }
+        // Ensure canvas has the latest from editorOriginalImageSrc if no previews are active
+        redrawOriginalImage(() => {
+            const dataURL = editorCanvas.toDataURL("image/png");
+            chrome.downloads.download({url:dataURL,filename:"edited-screenshot.png",saveAs:true},(id) => {
+              if(chrome.runtime.lastError)console.error("Save error:",chrome.runtime.lastError.message);
+              else if(!id)console.warn("Download not started."); else console.log("Image saved:",id);
+            });
+        });
+    });
+
+    copyToClipboardBtn.addEventListener('click', async () => {
+        if (!editorOriginalImageSrc && editorCanvas.width === 0) { alert("No image to copy."); return; }
+        redrawOriginalImage(async () => {
+            try {
+                editorCanvas.toBlob(async (blob) => {
+                    if (!blob) throw new Error("Blob creation failed.");
+                    await navigator.clipboard.write([ new ClipboardItem({ [blob.type]: blob }) ]);
+                    const originalText = copyToClipboardBtn.textContent;
+                    copyToClipboardBtn.textContent = 'Copied!'; copyToClipboardBtn.disabled = true;
+                    setTimeout(() => { copyToClipboardBtn.textContent = originalText; copyToClipboardBtn.disabled = false; }, 2000);
+                }, 'image/png');
+            } catch (err) {
+                console.error("Copy to clipboard error: ", err); alert("Copy error: " + err.message);
+                copyToClipboardBtn.disabled = false;
+            }
+        });
+    });
+
+    // Set initial tool (draw tool is default)
+    setActiveTool('draw');
+});

--- a/popup.html
+++ b/popup.html
@@ -42,6 +42,7 @@
   <div class="output-actions"> <!-- Grouping output buttons -->
     <button id="saveBtn">Save Image</button>
     <button id="copyToClipboardBtn">Copy to Clipboard</button>
+    <button id="openInEditorBtn" style="background-color: #545b62;">Open in Editor</button>
   </div>
   <script src="popup.js"></script>
 </body>


### PR DESCRIPTION
This commit introduces two major updates:

1.  **Fix for "Capture Selected Area":**
    - Addressed a bug where the selected area capture might not appear in the popup if the popup closed during selection.
    - Implemented a robust data transfer mechanism. The background script now saves the captured area image data (or any errors) to local storage.
    - The popup script checks this storage on load, ensuring the captured area or error message is reliably displayed to you.

2.  **Core "Open in Editor Tab" Feature:**
    - You can now open the current image (with any edits made in the popup) in a new, dedicated browser tab for a larger, more convenient editing experience.
    - Created the necessary HTML, JavaScript, and CSS files for this full-view editor.
    - Image data is transferred from the popup to the editor tab.
    - All existing editing functionalities (Draw, Text, Crop, Shapes), as well as "Save Image" and "Copy to Clipboard", have been ported and are functional within the new editor tab context.
    - The editor tab gracefully handles cases where no image data is sent (e.g., if opened directly).

These changes significantly improve the reliability of area capture and provide a much-requested enhancement for a more spacious editing environment.