### PR TITLE
fix: Add missing 'storage' permission and verify functionality

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,5 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["activeTab", "scripting", "downloads", "clipboardWrite"]
+  "permissions": ["activeTab", "scripting", "downloads", "clipboardWrite", "storage"]
 }


### PR DESCRIPTION
This commit addresses a critical bug where core functionalities like 'Capture Selected Area' and 'Open in Editor Tab' were failing. The root cause was identified as a missing "storage" permission in the `manifest.json` file, leading to a TypeError when trying to access `chrome.storage.local`.

- Added "storage" to the "permissions" array in `manifest.json`.
- Thoroughly tested the extension post-fix:
    - Confirmed the `TypeError` is resolved.
    - Verified that "Capture Selected Area" now reliably works, as it depends on `chrome.storage.local` for data transfer.
    - Verified that "Open in Editor Tab" also works correctly, as it uses `chrome.storage.local` to pass image data to the new editor tab.
    - All other editing and popup functionalities remain operational.

The extension should now be stable and all implemented features fully working.